### PR TITLE
Remove old rename migrations

### DIFF
--- a/modules/heroku/versions.tf
+++ b/modules/heroku/versions.tf
@@ -8,16 +8,3 @@ terraform {
     }
   }
 }
-
-moved {
-  from = heroku_addon.heroku_postgresql
-  to   = heroku_addon.heroku_postgresql[0]
-}
-moved {
-  from = heroku_addon.heroku_cloudamqp
-  to   = heroku_addon.heroku_cloudamqp[0]
-}
-moved {
-  from = heroku_addon.heroku_papertrail
-  to   = heroku_addon.heroku_papertrail[0]
-}


### PR DESCRIPTION
These were added by #58 and first released in `v0.12.0`.